### PR TITLE
Add nfpms to GoReleaser for .deb and .rpm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,7 +79,7 @@ changelog:
       regexp: '^.*?sec(\(.+\))??!?:.+$'
       order: 2
     - title: "Build process updates"
-      regexp: '^.*?(build|ci)(\(.+\))??!?:.+$S'
+      regexp: '^.*?(build|ci)(\(.+\))??!?:.+$'
       order: 3
     - title: "Dependency updates"
       regexp: '^.*?(.+)\(deps\)!?:.+$'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,7 +89,18 @@ changelog:
       order: 5
     - title: "Other updates"
       order: 999
-
-
+  
 checksum:
   name_template: "checksums.txt"
+
+
+nfpms:
+  - license: MIT
+    maintainer: timwehrle
+    homepage: https://github.com/timwehrle/asana
+    dependencies:
+      - git
+    description: A command-line interface for managing Asana directly from your terminal.
+    formats:
+      - deb
+      - rpm


### PR DESCRIPTION
This PR fixes #13.

Snapshot with GoReleaser works.