### PR TITLE
test: add unit tests for invalid limit and error handling in list com…

### DIFF
--- a/pkg/cmd/tags/list/list_test.go
+++ b/pkg/cmd/tags/list/list_test.go
@@ -1,13 +1,17 @@
 package list
 
 import (
-	"github.com/timwehrle/asana/internal/api/asana"
-	"github.com/timwehrle/asana/pkg/factory"
+	"errors"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/timwehrle/asana/internal/api/asana"
+	"github.com/timwehrle/asana/internal/config"
+	"github.com/timwehrle/asana/pkg/factory"
+	"github.com/timwehrle/asana/pkg/iostreams"
 )
 
 func TestNewCmdList_RunE(t *testing.T) {
@@ -32,6 +36,40 @@ func TestNewCmdList_RunE(t *testing.T) {
 	}
 	if !sawOpts.Favorite {
 		t.Error("Favorite = false; want true")
+	}
+}
+
+func TestNewCmdList_RunE_InvalidLimit(t *testing.T) {
+	f, _, _ := factory.NewTestFactory()
+	cmd := NewCmdList(f, func(opts *ListOptions) error { return nil })
+	cmd.SetArgs([]string{"--limit", "-1"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid limit") {
+		t.Fatalf("expected invalid-limit error, got %v", err)
+	}
+}
+
+func TestRunList_ConfigError(t *testing.T) {
+	io, _, _, _ := iostreams.Test()
+	opts := &ListOptions{
+		IO:     io,
+		Config: func() (*config.Config, error) { return nil, errors.New("no config") },
+		Client: func() (*asana.Client, error) { return nil, nil },
+	}
+	if err := runList(opts); err == nil || !strings.Contains(err.Error(), "failed to get config") {
+		t.Fatalf("expected config error, got %v", err)
+	}
+}
+
+func TestRunList_ClientError(t *testing.T) {
+	io, _, _, _ := iostreams.Test()
+	opts := &ListOptions{
+		IO:     io,
+		Config: func() (*config.Config, error) { return &config.Config{Workspace: &asana.Workspace{ID: "W"}}, nil },
+		Client: func() (*asana.Client, error) { return nil, errors.New("auth failed") },
+	}
+	if err := runList(opts); err == nil || !strings.Contains(err.Error(), "auth failed") {
+		t.Fatalf("expected client error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
This pull request enhances the test coverage for the `list` command in the `pkg/cmd/tags` package by adding new test cases for error scenarios and updating imports for better organization.

### Test coverage improvements:

* `pkg/cmd/tags/list/list_test.go`: Added three new test cases to handle specific error scenarios:
  - [`TestNewCmdList_RunE_InvalidLimit`](diffhunk://#diff-31ac2eb18b6007b1d3133e53630b16a67be3815524f49ac705eb95c6538209fbR42-R75): Validates that an invalid `--limit` argument results in an appropriate error message.
  - [`TestRunList_ConfigError`](diffhunk://#diff-31ac2eb18b6007b1d3133e53630b16a67be3815524f49ac705eb95c6538209fbR42-R75): Tests the behavior when configuration retrieval fails, ensuring the error message is descriptive.
  - [`TestRunList_ClientError`](diffhunk://#diff-31ac2eb18b6007b1d3133e53630b16a67be3815524f49ac705eb95c6538209fbR42-R75): Simulates a client authentication failure and checks for the correct error handling.

### Code organization improvements:

* [`pkg/cmd/tags/list/list_test.go`](diffhunk://#diff-31ac2eb18b6007b1d3133e53630b16a67be3815524f49ac705eb95c6538209fbL4-R14): Updated imports to include `errors`, `config`, and `iostreams` modules, organizing them logically and ensuring all dependencies are properly included.